### PR TITLE
fix: 修复AIAnalysisPanel中AICacheService导入错误

### DIFF
--- a/components/features/ai-analysis/AIAnalysisPanel.tsx
+++ b/components/features/ai-analysis/AIAnalysisPanel.tsx
@@ -16,7 +16,7 @@ import {
   type TrendAnalysisData,
   type PersonalizedAdviceData
 } from './AIAnalysisPanel/utils';
-import { AICacheService } from '@/lib/services/aiCacheService';
+import { aiCacheService } from '@/lib/services/aiCacheService';
 
 interface AIAnalysisPanelProps {
   className?: string;
@@ -83,13 +83,12 @@ export function AIAnalysisPanel({
 
       // 尝试从缓存加载 AI 分析结果
       const loadCachedAnalysis = async () => {
-        const cacheService = AICacheService.getInstance();
         const cacheKey = {
           month: currentMonth || new Date().toISOString().slice(0, 7),
           dataHash: JSON.stringify(aiData.currentMonthTop20).substring(0, 50) // 使用数据摘要作为key
         };
 
-        const cached = await cacheService.get<string>('ai_analysis', cacheKey);
+        const cached = await aiCacheService.get<string>('ai_analysis', cacheKey);
         if (cached) {
           console.log('✅ 从缓存加载AI分析结果');
           setAiSummary(cached);
@@ -153,12 +152,11 @@ export function AIAnalysisPanel({
             console.log('🤖 获得AI分析:', aiSummaryResult);
 
             // 3. 保存到缓存（30分钟有效期）
-            const cacheService = AICacheService.getInstance();
             const cacheKey = {
               month: currentMonth || new Date().toISOString().slice(0, 7),
               dataHash: JSON.stringify(aiData.currentMonthTop20).substring(0, 50)
             };
-            await cacheService.set('ai_analysis', aiSummaryResult, cacheKey);
+            await aiCacheService.set('ai_analysis', aiSummaryResult, cacheKey);
             console.log('💾 AI分析结果已缓存');
           }
         }


### PR DESCRIPTION
问题描述:
- AIAnalysisPanel组件导入了不存在的AICacheService类
- aiCacheService.ts只导出单例实例,不导出类本身
- 导致运行时错误: Cannot read properties of undefined (reading 'getInstance')

修复内容:
- 将导入从 { AICacheService } 改为 { aiCacheService }
- 移除所有 AICacheService.getInstance() 调用
- 直接使用导出的单例实例 aiCacheService

影响文件:
- components/features/ai-analysis/AIAnalysisPanel.tsx (line 19, 86, 155)