### PR TITLE
fix: 修复显示问题三项

### DIFF
--- a/app/home-page-data.ts
+++ b/app/home-page-data.ts
@@ -266,9 +266,9 @@ async function loadTopData(
       category: item.category,
       amount: item.total,
       date: item.latestDate,
-      note: item.merchant || item.note || `${item.count}笔消费`,
+      note: `共${item.count}笔消费`,
       currency,
-      merchant: item.merchant
+      merchant: undefined // 不显示商家信息，避免误导
     }));
 
   return aggregatedData;

--- a/components/features/transactions/TransactionList/GroupedList.tsx
+++ b/components/features/transactions/TransactionList/GroupedList.tsx
@@ -366,7 +366,8 @@ export function TransactionGroupedList({
     for (const transaction of transactions) {
       const date = transaction.date;
       const category = transaction.category || 'other';
-      const merchant = transaction.merchant || '未分类';
+      // 优先使用merchant，其次使用note，最后使用"无备注"
+      const merchant = transaction.merchant || transaction.note || '无备注';
       const amount = Number(transaction.amount || 0);
 
       // 初始化日期分组
@@ -529,7 +530,7 @@ export function TransactionGroupedList({
                   </span>
                 </div>
                 <div className="font-semibold text-red-600">
-                  -¥{formatCurrency(dateData.total, 'CNY')}
+                  -{formatCurrency(dateData.total, 'CNY')}
                 </div>
               </button>
 
@@ -561,7 +562,7 @@ export function TransactionGroupedList({
                               </span>
                             </div>
                             <div className="font-medium text-sm">
-                              ¥{formatCurrency(categoryData.total, 'CNY')}
+                              {formatCurrency(categoryData.total, 'CNY')}
                             </div>
                           </button>
 
@@ -600,7 +601,7 @@ export function TransactionGroupedList({
                                           )}
                                         </div>
                                         <div className="text-sm font-medium">
-                                          ¥{formatCurrency(merchantData.total, 'CNY')}
+                                          {formatCurrency(merchantData.total, 'CNY')}
                                         </div>
                                       </button>
 
@@ -621,7 +622,7 @@ export function TransactionGroupedList({
                                                   </div>
                                                   <div className="flex items-center gap-2">
                                                     <div className="text-xs font-medium">
-                                                      ¥{formatCurrency(Number(item.amount || 0), 'CNY')}
+                                                      {formatCurrency(Number(item.amount || 0), 'CNY')}
                                                     </div>
                                                     <div className="opacity-0 group-hover:opacity-100 flex gap-1">
                                                       <Button


### PR DESCRIPTION
## 问题1: 首页Top 10备注显示混乱
- 原问题：聚合后只显示其中一个商家名称，容易误导
- 解决：改为显示"共X笔消费"，不显示具体商家

## 问题2: 账单明细重复¥符号
- 原问题：formatCurrency已包含¥符号，再手动添加导致¥¥
- 解决：移除所有手动添加的¥符号
  - 日期层：-¥xxx → -xxx
  - 分类层：¥xxx → xxx
  - 商家层：¥xxx → xxx
  - 明细层：¥xxx → xxx

## 问题3: 账单明细显示"未分类"
- 原问题：没有merchant字段的记录都显示为"未分类"
- 解决：优先级调整为 merchant → note → "无备注"
- 现在会使用原有的备注内容作为商家名称

Claude Code Marker: 011CUhU7DMp7GxhR9oxJY78R