### PR TITLE
feat: 固定账单生成迁移到 Supabase Cron

### DIFF
--- a/hooks/useAutoGenerateRecurring.ts
+++ b/hooks/useAutoGenerateRecurring.ts
@@ -1,43 +1,14 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 
-interface AutoGenerateResult {
-  generated: number;
-  errors: string[];
-  message: string;
-}
-
+/**
+ * 固定账单状态展示 Hook
+ * 注意：自动生成逻辑已迁移到 Supabase Cron 定时任务
+ * 每天 00:01 自动执行，不再依赖前端触发
+ */
 export function useAutoGenerateRecurring(recurringExpenses: any[]) {
-  const [isChecking, setIsChecking] = useState(false);
-  const [lastResult, setLastResult] = useState<AutoGenerateResult | null>(null);
-
-  // 计算固定支出的生成状态
+  // 计算固定支出的生成状态（纯展示用）
   const getExpenseGenerationStatus = useCallback((expense: any) => {
     const today = new Date().toISOString().split('T')[0];
-    const todayDate = new Date();
-    const dayOfWeek = todayDate.getDay();
-
-    let shouldGenerateToday = false;
-
-    if (expense.is_active && expense.next_generate === today) {
-      switch (expense.frequency) {
-        case 'daily':
-          shouldGenerateToday = true;
-          break;
-        case 'weekly':
-          if (expense.frequency_config.days_of_week &&
-              expense.frequency_config.days_of_week.includes(dayOfWeek)) {
-            shouldGenerateToday = true;
-          }
-          break;
-        case 'monthly':
-          const todayDay = todayDate.getDate();
-          if (expense.frequency_config.day_of_month === todayDay) {
-            shouldGenerateToday = true;
-          }
-          break;
-      }
-    }
-
     const alreadyGeneratedToday = expense.last_generated === today;
 
     if (alreadyGeneratedToday) {
@@ -48,115 +19,18 @@ export function useAutoGenerateRecurring(recurringExpenses: any[]) {
         bgColor: 'bg-green-50',
         borderColor: 'border-green-200'
       };
-    } else if (shouldGenerateToday) {
-      return {
-        status: 'pending',
-        text: '⏰ 待生成',
-        color: 'text-amber-600',
-        bgColor: 'bg-amber-50',
-        borderColor: 'border-amber-200'
-      };
-    } else {
-      return {
-        status: 'scheduled',
-        text: `下次: ${expense.next_generate || '未设置'}`,
-        color: 'text-blue-600',
-        bgColor: 'bg-blue-50',
-        borderColor: 'border-blue-200'
-      };
     }
+
+    return {
+      status: 'scheduled',
+      text: `下次: ${expense.next_generate || '未设置'}`,
+      color: 'text-blue-600',
+      bgColor: 'bg-blue-50',
+      borderColor: 'border-blue-200'
+    };
   }, []);
 
-  // 获取今天的待生成数量
-  const getPendingCount = useCallback(() => {
-    return recurringExpenses.filter(e => getExpenseGenerationStatus(e).status === 'pending').length;
-  }, [recurringExpenses, getExpenseGenerationStatus]);
-
-  // 检查并生成待生成的固定支出
-  const checkAndGenerate = useCallback(async (showFeedback = false) => {
-    if (isChecking) return;
-
-    try {
-      setIsChecking(true);
-
-      // 双重检查机制：localStorage + 数据库校验
-      const today = new Date().toISOString().split('T')[0];
-      const lastCheckKey = 'recurring_expenses_last_check';
-      const lastCheck = localStorage.getItem(lastCheckKey);
-
-      // 第一层：localStorage检查
-      if (lastCheck === today) {
-        console.log('今天已经检查过固定支出，跳过');
-        return null;
-      }
-
-      // 第二层：数据库二次校验
-      // 检查今天是否已经有自动生成的交易记录
-      const todayTransactionsResponse = await fetch('/api/transactions/today-auto-generated');
-      if (todayTransactionsResponse.ok) {
-        const todayData = await todayTransactionsResponse.json();
-        if (todayData.count > 0) {
-          console.log('数据库检测到今天已生成记录，跳过自动生成');
-          localStorage.setItem(lastCheckKey, today);
-          return null;
-        }
-      }
-
-      // 检查是否有待生成的固定支出
-      const pendingCount = getPendingCount();
-
-      if (pendingCount > 0) {
-        console.log(`发现 ${pendingCount} 个待生成的固定支出，开始自动生成...`);
-
-        const response = await fetch('/api/recurring-expenses/generate', {
-          method: 'POST',
-        });
-
-        if (response.ok) {
-          const result: AutoGenerateResult = await response.json();
-          setLastResult(result);
-
-          console.log('自动生成结果:', result);
-
-          if (showFeedback && result.generated > 0) {
-            // 可以通过回调或自定义hook来显示提示
-            console.log(`✅ 自动生成 ${result.generated} 笔固定支出记录`);
-          }
-
-          // 记录今天已经检查过
-          localStorage.setItem(lastCheckKey, today);
-
-          return result;
-        } else {
-          console.error('自动生成失败:', response.status);
-          return null;
-        }
-      } else {
-        console.log('没有待生成的固定支出');
-        localStorage.setItem(lastCheckKey, today);
-        return null;
-      }
-
-    } catch (error) {
-      console.error('自动检查固定支出失败:', error);
-      return null;
-    } finally {
-      setIsChecking(false);
-    }
-  }, [isChecking, getPendingCount]);
-
-  // 自动检查（在数据加载完成时触发）
-  useEffect(() => {
-    if (recurringExpenses.length > 0) {
-      checkAndGenerate();
-    }
-  }, [recurringExpenses, checkAndGenerate]);
-
   return {
-    isChecking,
-    lastResult,
-    pendingCount: getPendingCount(),
-    checkAndGenerate,
     getExpenseGenerationStatus
   };
 }

--- a/lib/services/recurringService.ts
+++ b/lib/services/recurringService.ts
@@ -1,0 +1,70 @@
+import { supabase } from '@/lib/clients/supabase/client';
+
+export type RecurringGenerationResult = {
+  expense_name: string;
+  status: 'success' | 'failed' | 'skipped';
+  message: string;
+};
+
+/**
+ * 手动触发固定账单生成（调用 Supabase 函数）
+ */
+export async function manualGenerateRecurring(): Promise<RecurringGenerationResult[]> {
+  const { data, error } = await supabase.rpc('generate_recurring_transactions');
+
+  if (error) {
+    console.error('手动生成固定账单失败:', error);
+    throw error;
+  }
+
+  return data || [];
+}
+
+/**
+ * 查询固定账单生成历史
+ */
+export async function getGenerationHistory(limit = 20) {
+  const { data, error } = await supabase
+    .from('recurring_generation_logs')
+    .select(`
+      *,
+      recurring_expense:recurring_expenses(name, amount, category),
+      transaction:transactions(id, amount, note, date)
+    `)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    console.error('查询生成历史失败:', error);
+    throw error;
+  }
+
+  return data;
+}
+
+/**
+ * 查询今日生成统计
+ */
+export async function getTodayGenerationStats() {
+  const today = new Date().toISOString().split('T')[0];
+
+  const { data, error } = await supabase
+    .from('recurring_generation_logs')
+    .select('*', { count: 'exact' })
+    .eq('generation_date', today);
+
+  if (error) {
+    console.error('查询今日统计失败:', error);
+    throw error;
+  }
+
+  const successCount = data?.filter(d => d.status === 'success').length || 0;
+  const failedCount = data?.filter(d => d.status === 'failed').length || 0;
+
+  return {
+    total: data?.length || 0,
+    success: successCount,
+    failed: failedCount,
+    date: today
+  };
+}


### PR DESCRIPTION
架构重构：将固定账单生成逻辑从前端迁移到 Supabase 定时任务

## 主要变更

1. **useAutoGenerateRecurring Hook** (hooks/useAutoGenerateRecurring.ts)
   - 移除前端自动生成逻辑
   - 简化为纯展示状态 Hook
   - 添加注释说明：自动生成已迁移到 Supabase Cron

2. **新增 recurringService** (lib/services/recurringService.ts)
   - 创建 manualGenerateRecurring() - 调用 Supabase RPC 手动触发生成
   - 创建 getGenerationHistory() - 查询生成历史记录
   - 创建 getTodayGenerationStats() - 查询今日统计

3. **固定支出管理页面** (app/settings/expenses/recurring/page.tsx)
   - 更新为使用 Supabase RPC 代替 Next.js API
   - 修改按钮文案为"手动触发生成"（Zap 图标）
   - 优化生成结果提示信息
   - 移除对 lastResult 的监听

## 架构优势

- ✅ 时间驱动：每天 00:01 定时执行，不依赖用户行为
- ✅ 可靠性高：即使用户不打开应用也能准时生成
- ✅ 完整日志：所有生成记录存储在 recurring_generation_logs
- ✅ 手动触发：保留手动触发选项，方便测试和补生成

## 相关 SQL

- Supabase Cron 任务定义见 supabase/schema.sql
- 生成函数：generate_recurring_transactions()
- 执行时间：每天 00:01 (cron: '1 0 * * *')