### PR TITLE
fix: 修复支付方式管理缺少 payment_method 字段的问题

### DIFF
--- a/scripts/migrate-payment-method.ts
+++ b/scripts/migrate-payment-method.ts
@@ -1,0 +1,133 @@
+/**
+ * 数据库迁移脚本：为 transactions 表添加 payment_method 字段
+ *
+ * 使用方法：
+ * npx tsx scripts/migrate-payment-method.ts
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+
+// 加载环境变量
+dotenv.config({ path: '.env.local' });
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('❌ 错误：缺少 Supabase 配置');
+  console.error('请确保 .env.local 文件中设置了以下环境变量：');
+  console.error('  - NEXT_PUBLIC_SUPABASE_URL');
+  console.error('  - NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+async function runMigration() {
+  console.log('🚀 开始执行数据库迁移...\n');
+
+  try {
+    // 读取迁移 SQL 文件
+    const sqlPath = path.join(__dirname, '..', 'supabase', 'migrations', 'add_payment_method_to_transactions.sql');
+    const sql = fs.readFileSync(sqlPath, 'utf-8');
+
+    console.log('📄 读取迁移文件: add_payment_method_to_transactions.sql');
+    console.log('📝 SQL 内容长度:', sql.length, '字符\n');
+
+    // 分割 SQL 语句（按分号分割，但忽略函数体内的分号）
+    // 简单起见，我们直接执行整个 SQL 文件
+    // 注意：Supabase 客户端可能不支持执行包含多个语句的 SQL
+    // 如果遇到问题，需要手动在 Supabase Dashboard 中执行
+
+    console.log('⚠️  注意：由于 Supabase 客户端的限制，某些复杂 SQL 可能需要手动执行');
+    console.log('如果自动执行失败，请：');
+    console.log('1. 访问 Supabase Dashboard: ' + supabaseUrl.replace('.supabase.co', '.supabase.co/project/_/sql'));
+    console.log('2. 打开 SQL Editor');
+    console.log('3. 复制并执行 supabase/migrations/add_payment_method_to_transactions.sql 文件内容\n');
+
+    // 尝试执行 SQL（可能会因为权限或多语句问题失败）
+    console.log('🔧 尝试执行迁移...\n');
+
+    // 方法 1：尝试使用 rpc 调用（如果有权限）
+    const { data, error } = await supabase.rpc('exec_sql', { sql_query: sql }).catch(() => ({
+      data: null,
+      error: { message: 'exec_sql function not available' }
+    }));
+
+    if (error && error.message !== 'exec_sql function not available') {
+      throw error;
+    }
+
+    if (data !== null) {
+      console.log('✅ 迁移执行成功！');
+      console.log('📊 执行结果:', data);
+    } else {
+      // 方法 2：逐条执行关键步骤
+      console.log('📌 使用备用方案：逐条执行关键步骤...\n');
+
+      // 步骤 1：添加列
+      console.log('1️⃣  添加 payment_method 列...');
+      await supabase.rpc('exec', {
+        sql: 'ALTER TABLE public.transactions ADD COLUMN IF NOT EXISTS payment_method TEXT'
+      }).catch(() => {
+        console.log('   ℹ️  无法通过 RPC 执行，请手动添加列');
+      });
+
+      // 步骤 2：检查列是否存在
+      console.log('2️⃣  检查表结构...');
+      const { data: columns } = await supabase
+        .from('transactions')
+        .select('*')
+        .limit(1)
+        .single();
+
+      if (columns && 'payment_method' in columns) {
+        console.log('   ✅ payment_method 列已存在');
+      } else {
+        console.log('   ⚠️  payment_method 列不存在，需要手动执行迁移');
+        console.log('\n⚠️  请手动执行以下步骤：');
+        console.log('1. 访问 Supabase Dashboard SQL Editor');
+        console.log('2. 执行文件: supabase/migrations/add_payment_method_to_transactions.sql');
+        process.exit(1);
+      }
+
+      console.log('\n✅ 迁移完成！');
+    }
+
+    // 验证迁移结果
+    console.log('\n🔍 验证迁移结果...');
+
+    // 检查支付方式列表
+    const { data: paymentMethods, error: pmError } = await supabase.rpc('get_payment_methods_with_stats');
+
+    if (pmError) {
+      console.log('❌ 验证失败:', pmError.message);
+      console.log('\n请手动执行迁移文件，确保所有步骤都成功执行。');
+    } else {
+      console.log('✅ 支付方式查询成功！');
+      console.log('📊 当前支付方式数量:', paymentMethods?.length || 0);
+      if (paymentMethods && paymentMethods.length > 0) {
+        console.log('📋 支付方式列表:');
+        paymentMethods.forEach((pm: any) => {
+          console.log(`   - ${pm.name} (${pm.type}) - 使用次数: ${pm.usage_count}`);
+        });
+      }
+    }
+
+    console.log('\n🎉 迁移脚本执行完毕！');
+
+  } catch (error: any) {
+    console.error('\n❌ 迁移失败:', error.message);
+    console.error('\n请尝试手动执行迁移：');
+    console.error('1. 访问 Supabase Dashboard');
+    console.error('2. 进入 SQL Editor');
+    console.error('3. 执行 supabase/migrations/add_payment_method_to_transactions.sql');
+    process.exit(1);
+  }
+}
+
+// 运行迁移
+runMigration();

--- a/supabase/migrations/README.md
+++ b/supabase/migrations/README.md
@@ -1,0 +1,112 @@
+# 数据库迁移说明
+
+## 问题描述
+
+支付方式管理功能报错：`column t.payment_method does not exist`
+
+原因：`transactions` 表中缺少 `payment_method` 字段。
+
+## 解决方案
+
+### 方法一：使用 Supabase Dashboard（推荐）
+
+这是最简单、最可靠的方法：
+
+1. **访问 Supabase Dashboard**
+   - 打开你的 Supabase 项目
+   - 或访问：https://supabase.com/dashboard/project/YOUR_PROJECT_ID/sql
+
+2. **打开 SQL Editor**
+   - 在左侧菜单中找到 "SQL Editor"
+   - 点击 "New query"
+
+3. **执行迁移 SQL**
+   - 打开文件 `supabase/migrations/add_payment_method_to_transactions.sql`
+   - 复制所有内容
+   - 粘贴到 SQL Editor 中
+   - 点击 "Run" 按钮执行
+
+4. **验证结果**
+   - 执行成功后，刷新浏览器
+   - 返回应用的支付方式管理页面
+   - 检查是否能正常加载支付方式列表
+
+### 方法二：使用命令行脚本
+
+如果你更喜欢使用命令行：
+
+```bash
+# 安装 tsx（如果还没安装）
+npm install -D tsx
+
+# 运行迁移脚本
+npx tsx scripts/migrate-payment-method.ts
+```
+
+**注意**：由于 Supabase 客户端的限制，命令行脚本可能无法完全自动执行。如果遇到问题，请使用方法一。
+
+## 迁移内容
+
+此迁移会进行以下操作：
+
+1. ✅ 为 `transactions` 表添加 `payment_method` 字段（TEXT 类型）
+2. ✅ 创建索引以提升查询性能
+3. ✅ 将现有交易记录关联到默认支付方式（如果存在）
+4. ✅ 添加数据完整性检查函数
+
+## 迁移后的数据结构
+
+```sql
+-- transactions 表新增字段
+ALTER TABLE public.transactions
+ADD COLUMN payment_method TEXT;
+
+-- 索引
+CREATE INDEX idx_transactions_payment_method
+ON public.transactions(payment_method)
+WHERE deleted_at IS NULL;
+```
+
+## 验证迁移成功
+
+执行以下 SQL 查询来验证迁移是否成功：
+
+```sql
+-- 检查字段是否存在
+SELECT column_name, data_type
+FROM information_schema.columns
+WHERE table_name = 'transactions'
+AND column_name = 'payment_method';
+
+-- 测试支付方式查询
+SELECT * FROM get_payment_methods_with_stats();
+```
+
+## 回滚方案
+
+如果需要回滚此迁移：
+
+```sql
+-- 删除索引
+DROP INDEX IF EXISTS idx_transactions_payment_method;
+
+-- 删除函数
+DROP FUNCTION IF EXISTS check_payment_method_exists(TEXT);
+
+-- 删除字段
+ALTER TABLE public.transactions
+DROP COLUMN IF EXISTS payment_method;
+```
+
+## 注意事项
+
+- ⚠️ 此迁移会自动将现有交易关联到默认支付方式
+- ⚠️ 如果没有默认支付方式，现有交易的 `payment_method` 字段将为 NULL
+- ⚠️ 建议在执行迁移前先备份数据库
+
+## 相关文件
+
+- 迁移 SQL: `supabase/migrations/add_payment_method_to_transactions.sql`
+- 类型定义: `types/transaction.ts` （已更新）
+- 服务层: `lib/services/paymentMethodService.ts`
+- 原始表定义: `supabase/migrations/payment_methods_management.sql`

--- a/supabase/migrations/add_payment_method_to_transactions.sql
+++ b/supabase/migrations/add_payment_method_to_transactions.sql
@@ -1,0 +1,69 @@
+-- =====================================================
+-- 为 transactions 表添加 payment_method 字段
+-- 修复支付方式管理功能的数据库结构问题
+-- =====================================================
+
+-- 1. 添加 payment_method 字段到 transactions 表
+ALTER TABLE public.transactions
+ADD COLUMN IF NOT EXISTS payment_method TEXT;
+
+-- 2. 添加注释
+COMMENT ON COLUMN public.transactions.payment_method IS '支付方式 ID，关联到 payment_methods 表';
+
+-- 3. 创建索引以提升查询性能
+CREATE INDEX IF NOT EXISTS idx_transactions_payment_method
+ON public.transactions(payment_method)
+WHERE deleted_at IS NULL;
+
+-- 4. 可选：如果有默认支付方式，可以为现有记录设置默认值
+-- 注意：此步骤会将所有现有的交易记录关联到默认支付方式
+DO $$
+DECLARE
+  default_payment_method_id UUID;
+BEGIN
+  -- 获取默认支付方式的 ID
+  SELECT id INTO default_payment_method_id
+  FROM public.payment_methods
+  WHERE is_default = true AND is_active = true
+  LIMIT 1;
+
+  -- 如果有默认支付方式，更新所有没有支付方式的交易记录
+  IF default_payment_method_id IS NOT NULL THEN
+    UPDATE public.transactions
+    SET payment_method = default_payment_method_id::TEXT
+    WHERE payment_method IS NULL;
+
+    RAISE NOTICE '已将现有交易记录关联到默认支付方式: %', default_payment_method_id;
+  ELSE
+    RAISE NOTICE '未找到默认支付方式，跳过更新现有交易记录';
+  END IF;
+END $$;
+
+-- 5. 创建外键约束（可选，但建议添加以保证数据完整性）
+-- 注意：由于 payment_method 存储的是 TEXT 类型的 UUID，而不是直接的 UUID 外键
+-- 我们使用一个检查约束来确保引用的支付方式存在
+-- 如果需要更严格的约束，可以考虑将字段类型改为 UUID 并添加真正的外键
+
+-- 添加检查函数
+CREATE OR REPLACE FUNCTION check_payment_method_exists(payment_method_text TEXT)
+RETURNS BOOLEAN AS $$
+BEGIN
+  IF payment_method_text IS NULL THEN
+    RETURN TRUE;
+  END IF;
+
+  RETURN EXISTS(
+    SELECT 1
+    FROM public.payment_methods
+    WHERE id::TEXT = payment_method_text
+    AND is_active = true
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+-- 添加检查约束（可选，如果不想约束可以注释掉）
+-- ALTER TABLE public.transactions
+-- ADD CONSTRAINT check_valid_payment_method
+-- CHECK (check_payment_method_exists(payment_method));
+
+COMMENT ON FUNCTION check_payment_method_exists(TEXT) IS '检查支付方式是否存在且活跃';

--- a/types/transaction.ts
+++ b/types/transaction.ts
@@ -13,6 +13,7 @@ export interface Transaction {
   date: string; // ISO 日期字符串，如 2025-10-04
   created_at?: string;
   currency?: Currency; // 允许记录币种，默认 CNY
+  payment_method?: string; // 支付方式 ID，关联到 payment_methods 表
   // 新增优化字段
   merchant?: string; // 商家/品牌名称（如：瑞幸咖啡、地铁、美团）
   subcategory?: string; // 子分类（如：coffee、subway、takeout）


### PR DESCRIPTION
- 为 transactions 表添加 payment_method 字段的迁移脚本
- 更新 Transaction 类型定义，添加 payment_method 字段
- 创建自动化迁移脚本和详细说明文档
- 修复 get_payment_methods_with_stats 函数的 JOIN 查询错误

修复错误: column t.payment_method does not exist